### PR TITLE
Corrigido bug de conexões do endpoint `/migrations`

### DIFF
--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -3,34 +3,47 @@ import { join } from "node:path";
 import database from "infra/database";
 
 export default async function migrations(req, res) {
-  const dbClient = await database.getNewClient();
-  const defaultMigrationOptions = {
-    dbClient: dbClient,
-    dryRun: true,
-    dir: join("infra", "migrations"),
-    direction: "up",
-    verbose: true,
-    migrationsTable: "pgmigrations",
-  };
-
-  if (req.method == "GET") {
-    const pendingMigrations = await migrationRunner(defaultMigrationOptions);
-    await dbClient.end();
-    return res.status(200).json(pendingMigrations);
-  }
-  if (req.method == "POST") {
-    const migratedMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dryRun: false,
+  const allowedMethods = ["GET", "POST"];
+  if (!allowedMethods.includes(req.method)) {
+    return res.status(405).json({
+      message: `Method ${req.method} Not Allowed`,
     });
-    await dbClient.end();
+  }
 
-    if (migratedMigrations.length > 0) {
-      return res.status(201).json(migratedMigrations);
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const defaultMigrationOptions = {
+      dbClient: dbClient,
+      dryRun: true,
+      dir: join("infra", "migrations"),
+      direction: "up",
+      verbose: true,
+      migrationsTable: "pgmigrations",
+    };
+
+    if (req.method == "GET") {
+      const pendingMigrations = await migrationRunner(defaultMigrationOptions);
+      return res.status(200).json(pendingMigrations);
     }
 
-    return res.status(200).json(migratedMigrations);
-  }
+    if (req.method == "POST") {
+      const migratedMigrations = await migrationRunner({
+        ...defaultMigrationOptions,
+        dryRun: false,
+      });
 
-  return res.status(405).end();
+      if (migratedMigrations.length > 0)
+        return res.status(201).json(migratedMigrations);
+
+      return res.status(200).json(migratedMigrations);
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  } finally {
+    await dbClient.end();
+  }
 }


### PR DESCRIPTION
## Bug
Foi identificado que ao realizar requisições no endpoint `api/v1/migrations` utilizando métodos diferentes dos que são permitidos `GET` e `POST` as conexões com o banco de dados não eram fechadas.
Ao realizar uma requizição com o método `DELETE` e depois verificar a quantidade de conxões abertas com o endpoint `api/v1/status` foram exibidas duas conexões.

## Fix
Para resolver o problema foi implementada uma validação no inicio do endpoint `api/v1/migrations` que retorna o status `405` e uma mensagem no corpo da requisição informando que o método não é permitido por exemplo:
```
Method DELETE Not Allowed
```
Além da validação ser realizada antes que a conexão com o banco seja aberta, foi implementado um `try catch` onde a conexão com o banco é encerrada no `finally`.
Após a implementação foram realizados diversos testes disparando requisições com métodos como `PUT`, `DELETE` e ao verificar as conexões no `api/v1/status` o numero de `open_connections` sempre retornou 1.