### PR TITLE
Adicionado script `wait-for-postgres`

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -1,5 +1,6 @@
 services:
   database:
+    container_name: "postgres-dev"
     image: "postgres:16.8-alpine3.21"
     env_file:
       - ../.env.development

--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,0 +1,18 @@
+const { exec } = require("node:child_process");
+
+function checkPostgres() {
+  exec("docker exec postgres-dev pg_isready --host localhost", handleReturn);
+
+  function handleReturn(error, stdout) {
+    if (stdout.search("accepting connections") === -1) {
+      process.stdout.write("🟨");
+      checkPostgres();
+      return;
+    }
+    console.log("\n\n✅ PostgreSQL is ready\n");
+  }
+}
+
+process.stdout.write("\n\n🛑 Waiting for PostgreSQL to be ready...\n");
+
+checkPostgres();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Implementação do https://www.tabnews.com.br desenvolvida com as aulas do https://curso.dev",
   "main": "index.js",
   "scripts": {
-    "dev": "npm run services:up && next dev",
+    "dev": "npm run services:up && npm run wait-for-postgres && npm run migration:up && next dev",
     "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",
     "services:down": "docker compose -f infra/compose.yaml down",
@@ -13,7 +13,8 @@
     "test": "jest --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "migration:create": "node-pg-migrate -m infra/migrations create",
-    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up"
+    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up",
+    "wait-for-postgres": "node infra/scripts/wait-for-postgres.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
O script `dev` foi alterado para que além de executar o comando `services:up` ele também fique responsável por executar as migrations através do `migration:up`.
Para evitar que as migrations sejam executadas antes que o banco de dados esteja disponivel foi criado o comando `wait-for-postgres` que fica responsável por verificar se o banco de dados esta pronto para receber conexões, foi utilizado o comando:
```
docker exec postgres-dev pg_isready --host localhost
```
O resultado final pode ser observado no console executando o comando `npm run dev`:
![image](https://github.com/user-attachments/assets/b2b7af9c-c449-4401-afec-0a4b3c141db7)
