### PR TITLE
Refactor npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "services:down": "docker compose -f infra/compose.yaml down",
     "lint:check": "prettier --check .",
     "lint:fix": "prettier --write .",
-    "test": "npm run services:up && npm run wait-for-postgres && concurrently --n next,jest --hide next --k --s command-jest 'next dev' 'jest --runInBand'",
+    "test": "npm run services:up && concurrently -n next,jest --hide next -k -s command-jest \"next dev\" \"jest --runInBand --verbose\"",
     "test:watch": "jest --watchAll --runInBand",
     "migration:create": "node-pg-migrate -m infra/migrations create",
     "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up",

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -6,11 +6,13 @@ async function waitForAllServices() {
   async function waitForWebServer() {
     return retry(fetchStatusPage, {
       retries: 100,
+      maxTimeout: 1000
     });
 
     async function fetchStatusPage() {
       const response = await fetch("http://localhost:3000/api/v1/status");
-      await response.json();
+      
+      if (response.status !== 200) throw Error();
     }
   }
 }


### PR DESCRIPTION
### Garantindo compatibilidade com o Windows
Em ambientes windows a execução do comando `npm run test` estava dando erro ao tentar executar o comando `next dev`, neste ambiente esse comando precisa estar entre aspas duplas, para resolver o comando foi alterado para escapar as aspas duplas dentro do comando como pode ser observado abaixo:
```json
"scripts": {
    "test": "npm run services:up && concurrently -n next,jest --hide next -k -s command-jest \"next dev\" \"jest --runInBand --verbose\""
  },
```

### Garantindo a verificação da execução do serviço
A função `waitForAllServices` não estava verificando se o retorno da requisição era o status 200, isso deixava uma brecha para que se em algum cenário o retono fosse um status 500 o retono da função era que o serviço estava no ar.